### PR TITLE
Path escaping, adding email domain for better Google for work support.

### DIFF
--- a/src/upload.ts
+++ b/src/upload.ts
@@ -31,7 +31,7 @@ export const upload = async (
     puppeteerLaunch?: PuppeteerNodeLaunchOptions
 ) => {
     cookiesDirPath = path.join('.', 'yt-auth')
-    cookiesFilePath = path.join(cookiesDirPath, `cookies-${credentials.email.split('@')[0]}.json`)
+    cookiesFilePath = path.join(cookiesDirPath, `cookies-${credentials.email.split('@')[0].replace(/\./g, "_")}-${credentials.email.split('@')[1].replace(/\./g, "_")}.json`)
 
     await launchBrowser(puppeteerLaunch)
     await loadAccount(credentials)
@@ -254,7 +254,7 @@ export const update = async (
     puppeteerLaunch?: PuppeteerNodeLaunchOptions
 ) => {
     cookiesDirPath = path.join('.', 'yt-auth')
-    cookiesFilePath = path.join(cookiesDirPath, `cookies-${credentials.email.split('@')[0]}.json`)
+    cookiesFilePath = path.join(cookiesDirPath, `cookies-${credentials.email.split('@')[0].replace(/\./g, "_")}-${credentials.email.split('@')[1].replace(/\./g, "_")}.json`)
 
     await launchBrowser(puppeteerLaunch)
     if (!fs.existsSync(cookiesFilePath)) await loadAccount(credentials)


### PR DESCRIPTION
You can use Google Work accounts on YouTube and currently only the username is used as an index which could be a risk for overlap, now both username and domain will be used when saving cookies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fawazahmed0/youtube-uploader/55)
<!-- Reviewable:end -->
