### PR TITLE
Added skipping processing wait

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export interface Video {
     function?: any
     thumbnail?: string
     onSuccess?: Function
+	skipProcessingWait?: boolean
 }
 
 export interface VideoToEdit {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ export interface Video {
     function?: any
     thumbnail?: string
     onSuccess?: Function
-	skipProcessingWait?: boolean
+    skipProcessingWait?: boolean
 }
 
 export interface VideoToEdit {

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -108,7 +108,7 @@ async function uploadVideo(videoJSON: Video) {
     if ( !videoJSON.skipProcessingWait ) {
         await page.waitForXPath('//*[contains(text(),"Upload complete")]', { hidden: true, timeout: 0 })
     } else {
-        await sleep(5000);
+        await sleep(5000)
     }
     // Wait until title & description box pops up
     if (thumb) {

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -105,11 +105,11 @@ async function uploadVideo(videoJSON: Video) {
     // Wait for upload to complete
     await page.waitForXPath('//*[contains(text(),"Upload complete")]', { timeout: 0 })
     // Wait for upload to go away and processing to start, skip the wait if the user doesn't want it.
-	if ( !videoJSON.skipProcessingWait ) {
-		await page.waitForXPath('//*[contains(text(),"Upload complete")]', { hidden: true, timeout: 0 })
-	} else {
-		await sleep(5000);
-	}
+    if ( !videoJSON.skipProcessingWait ) {
+        await page.waitForXPath('//*[contains(text(),"Upload complete")]', { hidden: true, timeout: 0 })
+    } else {
+        await sleep(5000);
+    }
     // Wait until title & description box pops up
     if (thumb) {
         const [thumbChooser] = await Promise.all([

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -104,8 +104,12 @@ async function uploadVideo(videoJSON: Video) {
     await fileChooser.accept([pathToFile])
     // Wait for upload to complete
     await page.waitForXPath('//*[contains(text(),"Upload complete")]', { timeout: 0 })
-    // Wait for upload to go away and processing to start
-    await page.waitForXPath('//*[contains(text(),"Upload complete")]', { hidden: true, timeout: 0 })
+    // Wait for upload to go away and processing to start, skip the wait if the user doesn't want it.
+	if ( !videoJSON.skipProcessingWait ) {
+		await page.waitForXPath('//*[contains(text(),"Upload complete")]', { hidden: true, timeout: 0 })
+	} else {
+		await sleep(5000);
+	}
     // Wait until title & description box pops up
     if (thumb) {
         const [thumbChooser] = await Promise.all([


### PR DESCRIPTION
Should be fine, tried it and it worked for me.

Waiting for the processing can take a really really long time on videos that are 4hrs long in my use case it takes way.... too long and so I'm proposing this change, to allow people like me to skip waiting, won't affect anything unless the parameter is specified. Repost to fix indenting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fawazahmed0/youtube-uploader/57)
<!-- Reviewable:end -->
