### PR TITLE
Recursive lang change, refactor thumbnail selector, not work from 21/07/2022

### DIFF
--- a/src/upload.ts
+++ b/src/upload.ts
@@ -191,9 +191,9 @@ async function uploadVideo(videoJSON: Video) {
         const [thumbChooser] = await Promise.all([
             page.waitForFileChooser(),
             await page.waitForSelector(
-                `[class="remove-default-style style-scope ytcp-thumbnails-compact-editor-uploader"]`
+                `[class="remove-default-style style-scope ytcp-thumbnails-compact-editor-uploader-old"]`
             ),
-            await page.click(`[class="remove-default-style style-scope ytcp-thumbnails-compact-editor-uploader"]`)
+            await page.click(`[class="remove-default-style style-scope ytcp-thumbnails-compact-editor-uploader-old"]`)
         ])
         await thumbChooser.accept([thumb])
     }
@@ -771,8 +771,8 @@ async function changeHomePageLangIfNeeded(localPage: Page) {
         ).singleNodeValue as HTMLElement
         element.click()
     }, englishItemXPath)
-
-    await localPage.goto(uploadURL)
+    //Recursive language change, if YouTube, for some reason, did not change the language the first time, although the English (UK) button was pressed, the exit from the recursion occurs when the selectedLang selector is tested for the set language
+    await changeHomePageLangIfNeeded(localPage);
 }
 
 async function launchBrowser(puppeteerLaunch?: PuppeteerNodeLaunchOptions) {


### PR DESCRIPTION
Recursive language change, if YouTube, for some reason, did not change the language the first time, although the English (UK) button was pressed, the exit from the recursion occurs when the selectedLang selector is tested for the set language. And changed selector for choising thumbnail, youtube add  at the end.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fawazahmed0/youtube-uploader/137)
<!-- Reviewable:end -->
