### PR TITLE
feat: create `customSelectorUrl` config option

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -10,8 +10,10 @@ export interface Video {
     onSuccess?: (url: string) => void
     skipProcessingWait?: boolean
     onProgress?: (arg0: VideoProgress) => void
-    channelName?: string,
+    channelName?: string
     uploadAsDraft?: boolean
+    /** Allow setting of a custom selector URL to detect completion (e.g. if using shorts, set this to `https://youtube.com/shorts`) */
+    customSelectorUrl?: string
 }
 
 export enum ProgressEnum {

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -299,14 +299,15 @@ async function uploadVideo(videoJSON: Video) {
         "//*[normalize-space(text())='Publish']/parent::*[not(@disabled)] | //*[normalize-space(text())='Save']/parent::*[not(@disabled)]"
     await page.waitForXPath(publishXPath)
     // save youtube upload link
-    await page.waitForSelector('[href^="https://youtu.be"]')
-    const uploadedLinkHandle = await page.$('[href^="https://youtu.be"]')
+    const selector = videoJSON.customSelectorUrl ?? "https://youtu.be";
+    await page.waitForSelector(`[href^="${selector}"]`)
+    const uploadedLinkHandle = await page.$(`[href^="${selector}"]`)
 
     let uploadedLink
     do {
         await page.waitForTimeout(500)
         uploadedLink = await page.evaluate((e) => e.getAttribute('href'), uploadedLinkHandle)
-    } while (uploadedLink === 'https://youtu.be/')
+    } while (uploadedLink === selector)
 
     const closeDialogXPath = uploadAsDraft ? saveCloseBtnXPath : publishXPath    
     let closeDialog


### PR DESCRIPTION
This new configuration option lets the user decide what URL to look out for once video uploading has been completed.

For my use case, I want the script to detect when a short has been uploaded, which doesn't currently work (the URL generated by youtube starts with `https://youtube/shorts` rather than `https://youtu.be`, meaning the processing fails if it cannot find the uploaded short)

![0efcaa6389d861f7c1669070d2b1467e50abe51b034d989f04e1bf9e2ba4ba01](https://user-images.githubusercontent.com/48422312/181097602-ca1bdb94-d8b6-4538-8473-19a138162cc8.png)


This configuration option will allow the search selector to be set by the user in the `Video` object, like so:

![image](https://user-images.githubusercontent.com/48422312/181096989-1be97a64-d032-4425-bf26-2f21ee34aeea.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fawazahmed0/youtube-uploader/139)
<!-- Reviewable:end -->
