### PR TITLE
refactored work with tags

### DIFF
--- a/src/upload.ts
+++ b/src/upload.ts
@@ -265,8 +265,13 @@ async function uploadVideo(videoJSON: Video, messageTransport: MessageTransport)
     }
     // Add tags
     if (tags) {
-        await page.focus(`[aria-label="Tags"]`)
-        await page.type(`[aria-label="Tags"]`, tags.join(', ').substring(0, 495) + ', ')
+        const ariaTagsSelector = `[aria-label="Tags"]`;
+        if(await !page.$(ariaTagsSelector)){
+            const showMoreBtn = await page.$x(`//*[@id="toggle-button"]/div`)
+            await page.evaluate((el) => el.click(),showMoreBtn)
+        }
+        await page.focus(ariaTagsSelector)
+        await page.type(ariaTagsSelector, tags.join(', ').substring(0, 495) + ', ')
     }
 
     // Selecting video language


### PR DESCRIPTION
depending on changes at upload page, now check if need to click Show More button to show area with tags.

In headless mode virtual heigth of page is so small, and youtube hide the area with tags, and app get an error -Error: No element found for selector: [aria-label-"Tags"]. This pull request fix this issue by clicking on button show more.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fawazahmed0/youtube-uploader/145)
<!-- Reviewable:end -->
