### PR TITLE
Allow user to skip Processing wait

### DIFF
--- a/src/upload.ts
+++ b/src/upload.ts
@@ -174,20 +174,18 @@ async function uploadVideo(videoJSON: Video, messageTransport: MessageTransport)
     
     // Wait for upload to complete
     await page.waitForXPath('//*[contains(text(),"Upload complete")]', { timeout: 0 })
-    // Wait for upload to go away and processing to start
-    await page.waitForXPath('//*[contains(text(),"Upload complete")]', { hidden: true, timeout: 0 })
-
-    if (videoJSON.onProgress) {
-        progress = { progress: 0, stage: ProgressEnum.Processing }
-        videoJSON.onProgress(progress)
-    }
-
     // Wait for upload to go away and processing to start, skip the wait if the user doesn't want it.
     if (!videoJSON.skipProcessingWait) {
         await page.waitForXPath('//*[contains(text(),"Upload complete")]', { hidden: true, timeout: 0 })
     } else {
         await sleep(5000)
     }
+
+    if (videoJSON.onProgress) {
+        progress = { progress: 0, stage: ProgressEnum.Processing }
+        videoJSON.onProgress(progress)
+    }
+
     if (videoJSON.onProgress) {
         clearInterval(progressChecker)
         progressChecker = undefined


### PR DESCRIPTION
Currently we are waiting for the processing to start regardless of the value of skipProcessingWait. 

The code to wait was duplicated and so the skipProcessingWait option did nothing. 

There may be reasons not to skip, but i feel it is best to give the user a choice.

I have used this project as part to fully automate archiving of videos, shutting the pc off when done, and want the computer to be on the minimal amount of time, I don't want the computer sitting there waiting,

I don't need to wait for checks to compete or copyright if that was the reason for the change previously.

Thank you all for working on this project :)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fawazahmed0/youtube-uploader/162)
<!-- Reviewable:end -->
