### PR TITLE
Added support for pinning created comments

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,7 @@ export interface Comment {
     comment: string
     live?: boolean
     onSuccess?: Function
+    pin?: boolean
 }
 
 export interface Credentials {

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -527,10 +527,10 @@ const publishComment = (comment: Comment) => {
                                     observer.disconnect()
 
                                     // Resolve promise
-                                    // @ts-expect-error - commentResolve is exposed to the page on L745
+                                    // @ts-expect-error - commentResolve is exposed to the page
                                     window.commentResolve({ err: false, data: 'sucess' })
                                 } catch (err) {
-                                    // @ts-expect-error - commentResolve is exposed to the page on L745
+                                    // @ts-expect-error - commentResolve is exposed to the page
                                     window.commentResolve({ err: true, data: err })
                                 }
                             }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {            
-      "target": "ES6",                                
+      "target": "ES2017",                                
       "module": "commonjs",                           
       "lib": [
         "DOM",


### PR DESCRIPTION
This adds support for pinning comments created by the `publishComment` method.

## Changes
- Adds routine to pin newly created comments
- Adds `pin` optional boolean option to `Comment` object 
- Bumps `target` in tsconfig to ES2017 to support `async/await` syntax in injected code. See https://stackoverflow.com/a/68882897/17144515