### PR TITLE
improvement: close browser before throwing error

### DIFF
--- a/src/upload.ts
+++ b/src/upload.ts
@@ -50,19 +50,26 @@ export const upload = async (
     )
 
     await launchBrowser(puppeteerLaunch)
-    await loadAccount(credentials, messageTransport)
 
-    const uploadedYTLink: string[] = []
+    try {
+        await loadAccount(credentials, messageTransport)
 
-    for (const video of videos) {
-        const link = await uploadVideo(video, messageTransport)
+        const uploadedYTLink: string[] = []
 
-        const { onSuccess } = video
-        if (typeof onSuccess === 'function') {
-            onSuccess(link)
+        for (const video of videos) {
+            const link = await uploadVideo(video, messageTransport)
+
+            const { onSuccess } = video
+            if (typeof onSuccess === 'function') {
+                onSuccess(link)
+            }
+
+            uploadedYTLink.push(link)
         }
+    } catch (err) {
+        if (browser) await browser.close()
 
-        uploadedYTLink.push(link)
+        throw err;
     }
 
     await browser.close()


### PR DESCRIPTION
We should catch errors then close browser and throw the error because otherwise people like me who have this script in loop with own error handling will have memory leak because old browser stays in background.

Please check before mergeing. 