### PR TITLE
Fix Change Home Page Language selector

### DIFF
--- a/src/upload.ts
+++ b/src/upload.ts
@@ -1020,7 +1020,7 @@ async function changeHomePageLangIfNeeded(localPage: Page) {
     await localPage.click(avatarButtonSelector)
 
     const langMenuItemSelector =
-        '#sections>yt-multi-page-menu-section-renderer:nth-child(3)>#items>ytd-compact-link-renderer>a'
+        '#sections>yt-multi-page-menu-section-renderer:nth-child(3)>#items>ytd-compact-link-renderer:nth-of-type(2)>a'
     try {
         await localPage.waitForSelector(langMenuItemSelector)
     } catch (e: any) {


### PR DESCRIPTION
Fixed Change Home Page Language selector

Now both **Your data in YouTube** and **Language** options are `ytd-compact-link-renderer`, hence the second element must be selected. Here we cannot use `nth-child` we have to use `nth-of-type` https://github.com/puppeteer/puppeteer/issues/495

Hope it Helps
Thank You